### PR TITLE
Implement undo command

### DIFF
--- a/src/main/jmsandiegoo/tyrone/commands/Command.java
+++ b/src/main/jmsandiegoo/tyrone/commands/Command.java
@@ -1,6 +1,7 @@
 package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.exceptions.CommandExecutionException;
+import jmsandiegoo.tyrone.state.UndoState;
 import jmsandiegoo.tyrone.task.TaskList;
 
 /**

--- a/src/main/jmsandiegoo/tyrone/commands/CommandResult.java
+++ b/src/main/jmsandiegoo/tyrone/commands/CommandResult.java
@@ -13,6 +13,15 @@ public class CommandResult {
         this.commandResult = commandResultStr;
     }
 
+    public CommandResult chain(CommandResult... otherCommandResults) {
+        CommandResult newCommandResult = new CommandResult(this.commandResult);
+        for (CommandResult otherCommandResult : otherCommandResults) {
+            newCommandResult = new CommandResult(newCommandResult.commandResult
+                    + otherCommandResult.commandResult);
+        }
+        return newCommandResult;
+    }
+
     @Override
     public String toString() {
         return this.commandResult;

--- a/src/main/jmsandiegoo/tyrone/commands/DeadlineCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/DeadlineCommand.java
@@ -1,12 +1,13 @@
 package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.common.Messages;
+import jmsandiegoo.tyrone.state.UndoState;
 import jmsandiegoo.tyrone.task.Deadline;
 
 /**
  * Represents the command to add deadline tasks to the list.
  */
-public class DeadlineCommand extends Command {
+public class DeadlineCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "deadline";
     private final Deadline deadlineItem;
 
@@ -24,8 +25,18 @@ public class DeadlineCommand extends Command {
      */
     @Override
     public CommandResult execute() {
+        UndoState undoState = new UndoState();
+        undoState.setState(super.taskList);
+        super.undoState = undoState;
+
         super.taskList.addItem(this.deadlineItem);
         return new CommandResult(
                 String.format(Messages.MESSAGE_ADD_TASK, this.deadlineItem, super.taskList.getListSize()));
+    }
+
+    @Override
+    public CommandResult undo() {
+        super.taskList.restoreFromGivenList(super.undoState.getState());
+        return new CommandResult(Messages.MESSAGE_DEADLINE_UNDO);
     }
 }

--- a/src/main/jmsandiegoo/tyrone/commands/DeleteCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/DeleteCommand.java
@@ -2,12 +2,13 @@ package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.common.Messages;
 import jmsandiegoo.tyrone.exceptions.CommandExecutionException;
+import jmsandiegoo.tyrone.state.UndoState;
 import jmsandiegoo.tyrone.task.Task;
 
 /**
  * Represents the deletion command of task from the list.
  */
-public class DeleteCommand extends Command {
+public class DeleteCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "delete";
     private final int index;
 
@@ -26,6 +27,10 @@ public class DeleteCommand extends Command {
      */
     @Override
     public CommandResult execute() throws CommandExecutionException {
+        UndoState undoState = new UndoState();
+        undoState.setState(super.taskList);
+        super.undoState = undoState;
+
         try {
             Task delItem = super.taskList.deleteItem(this.index);
             return new CommandResult(
@@ -33,5 +38,11 @@ public class DeleteCommand extends Command {
         } catch (IndexOutOfBoundsException e) {
             throw new CommandExecutionException(String.format(Messages.MESSAGE_INCORRECT_COMMAND_INDEX, "delete"));
         }
+    }
+
+    @Override
+    public CommandResult undo() {
+        super.taskList.restoreFromGivenList(super.undoState.getState());
+        return new CommandResult(Messages.MESSAGE_DEADLINE_UNDO);
     }
 }

--- a/src/main/jmsandiegoo/tyrone/commands/EventCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/EventCommand.java
@@ -1,12 +1,13 @@
 package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.common.Messages;
+import jmsandiegoo.tyrone.state.UndoState;
 import jmsandiegoo.tyrone.task.Event;
 
 /**
  * Represents the command to add event into task list.
  */
-public class EventCommand extends Command {
+public class EventCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "event";
     private final Event eventItem;
 
@@ -24,8 +25,18 @@ public class EventCommand extends Command {
      */
     @Override
     public CommandResult execute() {
+        UndoState undoState = new UndoState();
+        undoState.setState(super.taskList);
+        super.undoState = undoState;
+
         super.taskList.addItem(this.eventItem);
         return new CommandResult(
                 String.format(Messages.MESSAGE_ADD_TASK, this.eventItem, super.taskList.getListSize()));
+    }
+
+    @Override
+    public CommandResult undo() {
+        super.taskList.restoreFromGivenList(super.undoState.getState());
+        return new CommandResult(Messages.MESSAGE_EVENT_UNDO);
     }
 }

--- a/src/main/jmsandiegoo/tyrone/commands/MarkCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/MarkCommand.java
@@ -2,11 +2,12 @@ package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.common.Messages;
 import jmsandiegoo.tyrone.exceptions.CommandExecutionException;
+import jmsandiegoo.tyrone.state.UndoState;
 
 /**
  * Represents the command to mark items as done.
  */
-public class MarkCommand extends Command {
+public class MarkCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "mark";
     private final int index;
 
@@ -25,6 +26,10 @@ public class MarkCommand extends Command {
      */
     @Override
     public CommandResult execute() throws CommandExecutionException {
+        UndoState undoState = new UndoState();
+        undoState.setState(super.taskList);
+        super.undoState = undoState;
+
         try {
             super.taskList.markItemDone(this.index);
             return new CommandResult(
@@ -32,5 +37,11 @@ public class MarkCommand extends Command {
         } catch (IndexOutOfBoundsException e) {
             throw new CommandExecutionException(String.format(Messages.MESSAGE_INCORRECT_COMMAND_INDEX, "mark"));
         }
+    }
+
+    @Override
+    public CommandResult undo() {
+        super.taskList.restoreFromGivenList(super.undoState.getState());
+        return new CommandResult(Messages.MESSAGE_MARK_UNDO);
     }
 }

--- a/src/main/jmsandiegoo/tyrone/commands/TodoCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/TodoCommand.java
@@ -1,12 +1,13 @@
 package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.common.Messages;
+import jmsandiegoo.tyrone.state.UndoState;
 import jmsandiegoo.tyrone.task.ToDo;
 
 /**
  * Represents the command to add a todo task in the list.
  */
-public class TodoCommand extends Command {
+public class TodoCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "todo";
     private final ToDo toDoItem;
 
@@ -24,8 +25,18 @@ public class TodoCommand extends Command {
      */
     @Override
     public CommandResult execute() {
+        UndoState undoState = new UndoState();
+        undoState.setState(super.taskList);
+        super.undoState = undoState;
+
         super.taskList.addItem(this.toDoItem);
         return new CommandResult(
                 String.format(Messages.MESSAGE_ADD_TASK, this.toDoItem, super.taskList.getListSize()));
+    }
+
+    @Override
+    public CommandResult undo() {
+        super.taskList.restoreFromGivenList(super.undoState.getState());
+        return new CommandResult(Messages.MESSAGE_TODO_UNDO);
     }
 }

--- a/src/main/jmsandiegoo/tyrone/commands/UndoCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/UndoCommand.java
@@ -1,0 +1,16 @@
+package jmsandiegoo.tyrone.commands;
+
+import jmsandiegoo.tyrone.common.Messages;
+import jmsandiegoo.tyrone.exceptions.CommandExecutionException;
+
+/**
+ * Represents the undo command itself of the application.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+
+    @Override
+    public CommandResult execute() throws CommandExecutionException {
+        return new CommandResult(Messages.MESSAGE_UNDO);
+    }
+}

--- a/src/main/jmsandiegoo/tyrone/commands/UndoableCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/UndoableCommand.java
@@ -1,0 +1,17 @@
+package jmsandiegoo.tyrone.commands;
+
+import jmsandiegoo.tyrone.state.UndoState;
+
+/**
+ * Represents commands that can be undone by the user.
+ */
+public abstract class UndoableCommand extends Command {
+    protected UndoState undoState;
+
+    /**
+     * Returns command result after undoing the command.
+     *
+     * @return CommandResult.
+     */
+    public abstract CommandResult undo();
+}

--- a/src/main/jmsandiegoo/tyrone/commands/UnmarkCommand.java
+++ b/src/main/jmsandiegoo/tyrone/commands/UnmarkCommand.java
@@ -2,11 +2,12 @@ package jmsandiegoo.tyrone.commands;
 
 import jmsandiegoo.tyrone.common.Messages;
 import jmsandiegoo.tyrone.exceptions.CommandExecutionException;
+import jmsandiegoo.tyrone.state.UndoState;
 
 /**
  * Represents the command to unmark an item in the list.
  */
-public class UnmarkCommand extends Command {
+public class UnmarkCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "unmark";
     private final int index;
 
@@ -25,6 +26,10 @@ public class UnmarkCommand extends Command {
      */
     @Override
     public CommandResult execute() throws CommandExecutionException {
+        UndoState undoState = new UndoState();
+        undoState.setState(super.taskList);
+        super.undoState = undoState;
+
         try {
             super.taskList.unmarkItemDone(this.index);
             return new CommandResult(
@@ -32,5 +37,11 @@ public class UnmarkCommand extends Command {
         } catch (IndexOutOfBoundsException e) {
             throw new CommandExecutionException(String.format(Messages.MESSAGE_INCORRECT_COMMAND_INDEX, "unmark"));
         }
+    }
+
+    @Override
+    public CommandResult undo() {
+        super.taskList.restoreFromGivenList(super.undoState.getState());
+        return new CommandResult(Messages.MESSAGE_UNMARK_UNDO);
     }
 }

--- a/src/main/jmsandiegoo/tyrone/common/Messages.java
+++ b/src/main/jmsandiegoo/tyrone/common/Messages.java
@@ -8,14 +8,6 @@ public class Messages {
     public static String MESSAGE_ADD_TASK = "Got it added homie:\n\n%1s\n"
             + "Now you have %2d in the list.";
 
-    public static String MESSAGE_VERTICAL_DIVIDER = " | ";
-
-    public static String MESSAGE_SQUARE_BRACKET_OPEN = "[";
-
-    public static String MESSAGE_SQUARE_BRACKET_CLOSE = "]";
-
-    public static String MESSAGE_EMPTY_SPACE = " ";
-
     /* General Exception messages */
     public static String MESSAGE_NOT_EXIST_CMD = "Command entered doesn't exist.";
 
@@ -33,6 +25,7 @@ public class Messages {
     /* Todo command messages */
     public static String MESSAGE_TODO_EMPTY_DESC = "Can't leave that to-do description hanging dry. "
             + "Gotta drop some words in there!";
+    public static String MESSAGE_TODO_UNDO = "Todo command undone.";
 
     /* Deadline command messages */
     public static String MESSAGE_DEADLINE_INCORRECT = String.format(
@@ -40,6 +33,7 @@ public class Messages {
             "deadline",
             "\"deadline <task description> /by <yyyy-mm-dd[ HH:mm]>\""
     );
+    public static String MESSAGE_DEADLINE_UNDO = "Deadline command undone.";
 
     /* Event command messages */
     public static String MESSAGE_EVENT_INCORRECT = String.format(
@@ -47,16 +41,20 @@ public class Messages {
             "event",
             "\"event <task description> /from <yyyy-mm-dd[ HH:mm]> /to <yyyy-mm-dd[ HH:mm]>\""
     );
+    public static String MESSAGE_EVENT_UNDO = "Event command undone.";
 
     /* Mark command messages */
     public static String MESSAGE_MARK = "Dope! Check it, I've tagged this task as handled:\n%1s";
+    public static String MESSAGE_MARK_UNDO = "Mark command undone.";
 
     /* Unmark command messages */
     public static String MESSAGE_UNMARK = "A'ight, I've stamped this task as still in the works:\n%1s";
 
+    public static String MESSAGE_UNMARK_UNDO = "Unmark command undone.";
     /* Delete command messages */
     public static String MESSAGE_DELETE = "Boom! Task officially evicted from the list. Consider it gone:\n%1s\n"
             + "Now you have %2d in the list.";
+    public static String MESSAGE_DELETE_UNDO = "Delete command undone.";
 
     /* Find command messages */
     public static String MESSAGE_FIND = "Yo, check it out, here's the lineup of tasks that match up:\n%1s";
@@ -65,4 +63,7 @@ public class Messages {
             "find",
             "\"find <keyword>\""
     );
+
+    /* Undo command messages */
+    public static String MESSAGE_UNDO = "Undo command detected: \n";
 }

--- a/src/main/jmsandiegoo/tyrone/parser/Parser.java
+++ b/src/main/jmsandiegoo/tyrone/parser/Parser.java
@@ -55,6 +55,9 @@ public class Parser {
         case ListCommand.COMMAND_WORD:
             command = parseListCommandArgs(arguments);
             break;
+        case UndoCommand.COMMAND_WORD:
+            command = parseUndoCommandArgs(arguments);
+            break;
         case TodoCommand.COMMAND_WORD:
             command = parseTodoCommandArgs(arguments);
             break;
@@ -79,6 +82,7 @@ public class Parser {
         default:
             throw new IncorrectCommandException(Messages.MESSAGE_NOT_EXIST_CMD);
         }
+
         return command;
     }
 
@@ -97,6 +101,15 @@ public class Parser {
         }
 
         return new ListCommand();
+    }
+
+    private Command parseUndoCommandArgs(String arguments) throws IncorrectCommandException {
+        if (!arguments.trim().isEmpty()) {
+            throw new IncorrectCommandException(
+                    String.format(Messages.MESSAGE_INCORRECT_COMMAND_FORMAT, "undo", "no arguments allowed"));
+        }
+
+        return new UndoCommand();
     }
 
     private Command parseTodoCommandArgs(String arguments) throws IncorrectCommandException {

--- a/src/main/jmsandiegoo/tyrone/state/StateManager.java
+++ b/src/main/jmsandiegoo/tyrone/state/StateManager.java
@@ -1,0 +1,49 @@
+package jmsandiegoo.tyrone.state;
+
+import jmsandiegoo.tyrone.commands.CommandResult;
+import jmsandiegoo.tyrone.commands.UndoableCommand;
+import jmsandiegoo.tyrone.task.TaskList;
+
+import java.util.Stack;
+
+/**
+ * Represents the class the manages the command history
+ * stack for undo commands.
+ */
+public class StateManager {
+    private final TaskList taskList;
+    private final Stack<UndoableCommand> commandStack;
+
+    public StateManager() {
+        this.taskList = new TaskList();
+        this.commandStack = new Stack<>();
+    }
+
+    public TaskList getTaskList() {
+        return this.taskList;
+    }
+
+    /**
+     * Adds undoable command into the history stack for undo feature.
+     *
+     * @param command - the undoable command entered by the user.
+     */
+    public void addCommandToStack(UndoableCommand command) {
+        commandStack.push(command);
+    }
+
+    /**
+     * Returns command result after undoing the most recent
+     * command from the stack.
+     *
+     * @return CommandResult - the result output of the command undo.
+     */
+    public CommandResult popCommandFromStack() {
+        if (this.commandStack.isEmpty()) {
+            return new CommandResult("No previous commands left to undo.");
+        }
+
+        UndoableCommand command = commandStack.pop();
+        return command.undo();
+    }
+}

--- a/src/main/jmsandiegoo/tyrone/state/UndoState.java
+++ b/src/main/jmsandiegoo/tyrone/state/UndoState.java
@@ -1,0 +1,18 @@
+package jmsandiegoo.tyrone.state;
+
+import jmsandiegoo.tyrone.task.TaskList;
+
+/**
+ * Represents the previous state for undo feature.
+ */
+public class UndoState {
+    private TaskList taskList;
+
+    public TaskList getState() {
+        return this.taskList;
+    }
+
+    public void setState(TaskList taskList) {
+        this.taskList = taskList.copy();
+    }
+}

--- a/src/main/jmsandiegoo/tyrone/task/Deadline.java
+++ b/src/main/jmsandiegoo/tyrone/task/Deadline.java
@@ -30,6 +30,17 @@ public class Deadline extends Task {
     }
 
     @Override
+    public Task copy() {
+        Deadline deadlineCopy = new Deadline(
+                super.description,
+                this.deadlineDateTime
+        );
+        deadlineCopy.isDone = this.isDone;
+
+        return deadlineCopy;
+    }
+
+    @Override
     public String serializeTask() {
         String taskTypeSerializedStr = "D | ";
         String deadlineDateTimeSerializedStr = " | "

--- a/src/main/jmsandiegoo/tyrone/task/Event.java
+++ b/src/main/jmsandiegoo/tyrone/task/Event.java
@@ -32,6 +32,18 @@ public class Event extends Task {
     }
 
     @Override
+    public Task copy() {
+        Event eventCopy = new Event(
+                super.description,
+                this.startDateTime,
+                this.endDateTime
+        );
+        eventCopy.isDone = this.isDone;
+
+        return eventCopy;
+    }
+
+    @Override
     public String serializeTask() {
         String taskSerializedStr = "E | "
                 + super.serializeTask()

--- a/src/main/jmsandiegoo/tyrone/task/Task.java
+++ b/src/main/jmsandiegoo/tyrone/task/Task.java
@@ -6,8 +6,8 @@ import jmsandiegoo.tyrone.common.Messages;
  * Represents the abstract task item of the application.
  */
 public abstract class Task {
-    private final String description;
-    private boolean isDone;
+    protected final String description;
+    protected boolean isDone;
 
     /**
      * @param description - the description of the task.
@@ -45,10 +45,16 @@ public abstract class Task {
     public String toString() {
         String isDoneStr = "[" + (this.isDone ? "X" : " ") + "] ";
 
-        return
-                isDoneStr
+        return isDoneStr
                 + this.description;
     }
+
+    /**
+     * Returns a copy of the particular task object.
+     *
+     * @return Task.
+     */
+    public abstract Task copy();
 
     /**
      * Returns String the encoded format of the task to be stored for file storage.

--- a/src/main/jmsandiegoo/tyrone/task/TaskList.java
+++ b/src/main/jmsandiegoo/tyrone/task/TaskList.java
@@ -161,6 +161,34 @@ public class TaskList {
     }
 
     /**
+     * Returns a new copy of the task list.
+     *
+     * @return TaskList.
+     */
+    public TaskList copy() {
+        TaskList taskListCopy = new TaskList();
+        for (Task item : this.items) {
+            taskListCopy.addItem(item.copy());
+        }
+
+        return taskListCopy;
+    }
+
+    /**
+     * Restores the current task list to the state provided as the
+     * parameter.
+     *
+     * @param restoreTaskList - the state to restore to.
+     */
+    public void restoreFromGivenList(TaskList restoreTaskList) {
+        this.items.clear();
+
+        for (int i = 0; i < restoreTaskList.getListSize(); ++i) {
+            this.items.add(restoreTaskList.getItem(i));
+        }
+    }
+
+    /**
      * Returns the task items from the list with the keyword.
      *
      * @param keyword - the target keyword to search for.

--- a/src/main/jmsandiegoo/tyrone/task/ToDo.java
+++ b/src/main/jmsandiegoo/tyrone/task/ToDo.java
@@ -17,6 +17,14 @@ public class ToDo extends Task {
     }
 
     @Override
+    public Task copy() {
+        ToDo todoCopy = new ToDo(super.description);
+        todoCopy.isDone = super.isDone;
+
+        return todoCopy;
+    }
+
+    @Override
     public String serializeTask() {
         String taskTypeSerializedStr = "T | ";
         return taskTypeSerializedStr

--- a/src/main/resources/views/ChatDialog.fxml
+++ b/src/main/resources/views/ChatDialog.fxml
@@ -7,6 +7,6 @@
 <fx:root type="javafx.scene.layout.HBox" stylesheets="@styles.css" styleClass="chat-dialog-hbox"
          xmlns="http://javafx.com/javafx/17"
          xmlns:fx="http://javafx.com/fxml/1">
-    <Label fx:id="message" text="Label" styleClass="chat-dialog-message"/>
+    <Label fx:id="message" minHeight="-Infinity" text="Label" styleClass="chat-dialog-message"/>
     <ImageView fx:id="displayPicture" fitHeight="70.0" fitWidth="60.0" pickOnBounds="true" preserveRatio="true"/>
 </fx:root>


### PR DESCRIPTION
User could not undo the recent commands they made in the application.

Create a new class named Undoable that follows the Memento pattern. This class should contain the previous state and have an undo function. Any commands eligible for undoing should implement this undo function. Additionally, create a StateManager class to manage history stack for the undo feature.

The code tries to follow the design pattern for such feature providing a clear structure for managing undoable commands. Though it can be improved in the next iteration with max stack size and not deep copying the state for each execute and undo commands that occurs.